### PR TITLE
Add code and configurations to push Servo metrics to InfluxDb via

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <zookeeper-version>3.4.9</zookeeper-version>
         <cfg4j-core-version>4.4.1</cfg4j-core-version>
         <commons-text-version>1.1</commons-text-version>
+        <servo-version>0.12.17</servo-version>
     </properties>
 
     <dependencies>
@@ -97,6 +98,18 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
             <version>${commons-text-version}</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.netflix.servo/servo-core -->
+        <dependency>
+            <groupId>com.netflix.servo</groupId>
+            <artifactId>servo-core</artifactId>
+            <version>${servo-version}</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.netflix.servo/servo-graphite -->
+        <dependency>
+            <groupId>com.netflix.servo</groupId>
+            <artifactId>servo-graphite</artifactId>
+            <version>${servo-version}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/src/main/java/com/expedia/www/haystack/external/GraphiteConfig.java
+++ b/src/main/java/com/expedia/www/haystack/external/GraphiteConfig.java
@@ -1,0 +1,11 @@
+package com.expedia.www.haystack.external;
+
+public interface GraphiteConfig {
+    String prefix();
+
+    String address();
+
+    int port();
+
+    int pollIntervalSeconds();
+}

--- a/src/main/java/com/expedia/www/haystack/external/ProtobufToJsonTransformer.java
+++ b/src/main/java/com/expedia/www/haystack/external/ProtobufToJsonTransformer.java
@@ -1,6 +1,15 @@
 package com.expedia.www.haystack.external;
 
 import com.expedia.open.tracing.Span;
+import com.netflix.servo.publish.AsyncMetricObserver;
+import com.netflix.servo.publish.BasicMetricFilter;
+import com.netflix.servo.publish.CounterToRateMetricTransform;
+import com.netflix.servo.publish.MetricObserver;
+import com.netflix.servo.publish.MetricPoller;
+import com.netflix.servo.publish.MonitorRegistryMetricPoller;
+import com.netflix.servo.publish.PollRunnable;
+import com.netflix.servo.publish.PollScheduler;
+import com.netflix.servo.publish.graphite.GraphiteMetricObserver;
 import org.apache.commons.text.StrSubstitutor;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serde;
@@ -19,7 +28,9 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 public class ProtobufToJsonTransformer {
 
@@ -32,6 +43,8 @@ public class ProtobufToJsonTransformer {
     private static ConfigFilesProvider cfp = () -> Collections.singletonList(Paths.get("base.yaml"));
     private static ClasspathConfigurationSource ccs = new ClasspathConfigurationSource(cfp);
     private static ConfigurationProvider cp = new ConfigurationProviderBuilder().withConfigurationSource(ccs).build();
+    private static final KafkaConfig kafkaConfig = cp.bind("haystack.kafka", KafkaConfig.class);
+    private static final GraphiteConfig graphiteConfig = cp.bind("haystack.graphite", GraphiteConfig.class);
 
     // TODO Move topics to a centralized location to be used by all services
     static final String KAFKA_FROM_TOPIC = "SpanObject-ProtobufFormat-Topic-1";
@@ -41,6 +54,7 @@ public class ProtobufToJsonTransformer {
     static final String KLASS_SIMPLE_NAME = ProtobufToJsonTransformer.class.getSimpleName();
 
     public static void main(String[] args) {
+        initMetricsPublishing();
         final SpanProtobufDeserializer protobufDeserializer = new SpanProtobufDeserializer();
         final SpanJsonSerializer spanJsonSerializer = new SpanJsonSerializer();
         final Serde<Span> spanSerde = Serdes.serdeFrom(spanJsonSerializer, protobufDeserializer);
@@ -56,6 +70,35 @@ public class ProtobufToJsonTransformer {
         logger.info(STARTED_MSG);
     }
 
+    private static void initMetricsPublishing() {
+        final List<MetricObserver> observers = Collections.singletonList(createGraphiteObserver());
+        PollScheduler.getInstance().start();
+        schedule(new MonitorRegistryMetricPoller(), observers);
+    }
+
+    private static void schedule(MetricPoller poller, List<MetricObserver> observers) {
+        final PollRunnable task = new PollRunnable(poller, BasicMetricFilter.MATCH_ALL,
+                true, observers);
+        PollScheduler.getInstance().addPoller(task, graphiteConfig.pollIntervalSeconds(), TimeUnit.SECONDS);
+    }
+
+    private static MetricObserver createGraphiteObserver() {
+        final String rawAddress = graphiteConfig.address() + ":" + graphiteConfig.port();
+        final String address = StrSubstitutor.replaceSystemProperties(rawAddress);
+        return rateTransform(async(new GraphiteMetricObserver(graphiteConfig.prefix(), address)));
+    }
+
+    private static MetricObserver rateTransform(MetricObserver observer) {
+        final long heartbeat = 2 * graphiteConfig.pollIntervalSeconds();
+        return new CounterToRateMetricTransform(observer, heartbeat, TimeUnit.SECONDS);
+    }
+
+    private static MetricObserver async(MetricObserver observer) {
+        final long expireTime = 2000 * graphiteConfig.pollIntervalSeconds();
+        final int queueSize = 10;
+        return new AsyncMetricObserver("graphite", observer, queueSize, expireTime);
+    }
+
     static Properties getProperties() {
         final Properties props = new Properties();
         props.put(StreamsConfig.CLIENT_ID_CONFIG, CLIENT_ID);
@@ -68,7 +111,6 @@ public class ProtobufToJsonTransformer {
     }
 
     private static String getKafkaIpAnPort() {
-        final KafkaConfig kafkaConfig = cp.bind("haystack.kafka", KafkaConfig.class);
         return StrSubstitutor.replaceSystemProperties(kafkaConfig.brokers()) + ":" + kafkaConfig.port();
     }
 

--- a/src/main/java/com/expedia/www/haystack/external/SpanJsonSerializer.java
+++ b/src/main/java/com/expedia/www/haystack/external/SpanJsonSerializer.java
@@ -3,18 +3,34 @@ package com.expedia.www.haystack.external;
 import com.expedia.open.tracing.Span;
 import com.google.protobuf.util.JsonFormat;
 import com.google.protobuf.util.JsonFormat.Printer;
+import com.netflix.servo.DefaultMonitorRegistry;
+import com.netflix.servo.annotations.Monitor;
+import com.netflix.servo.monitor.Counter;
+import com.netflix.servo.monitor.Monitors;
 import org.apache.kafka.common.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.charset.Charset;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.netflix.servo.annotations.DataSourceType.COUNTER;
 
 public class SpanJsonSerializer implements Serializer<Span> {
     static final String ERROR_MSG = "Problem serializing span [%s]";
     static Printer printer = JsonFormat.printer().omittingInsignificantWhitespace();
     static Logger logger = LoggerFactory.getLogger(SpanJsonSerializer.class);
 
+    static final Counter requestCount = Monitors.newCounter("requestCount");
+    static final Counter errorCount = Monitors.newCounter("errorCount");
+    static final Counter bytesIn = Monitors.newCounter("bytesIn");
+
+    static {
+        DefaultMonitorRegistry.getInstance().register(requestCount);
+        DefaultMonitorRegistry.getInstance().register(errorCount);
+        DefaultMonitorRegistry.getInstance().register(bytesIn);
+    }
     @Override
     public void configure(Map<String, ?> map, boolean b) {
         // Nothing to do
@@ -23,9 +39,12 @@ public class SpanJsonSerializer implements Serializer<Span> {
     @Override
     public byte[] serialize(String key, Span span) {
         try {
-            return printer.print(span).getBytes(Charset.forName("UTF-8"));
-            // TODO metrics (count, maybe latency, maybe message size)
+            requestCount.increment();
+            final byte[] bytes = printer.print(span).getBytes(Charset.forName("UTF-8"));
+            bytesIn.increment(bytes.length);
+            return bytes;
         } catch (Exception exception) {
+            errorCount.increment();
             logger.error(ERROR_MSG, span, exception);
         }
         return null;

--- a/src/main/resources/base.yaml
+++ b/src/main/resources/base.yaml
@@ -6,3 +6,8 @@ haystack:
   pipe:
     streams:
       replicationFactor: 1
+  graphite:
+     prefix: "haystack"
+     address: "haystack.local" # set in /etc/hosts per instructions in haystack-deployment package
+     port: 2003 # default Graphite port, rarely overridden, but can be overridden by env variable
+     pollIntervalSeconds: 60

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,6 +9,9 @@
     <logger name="com.expedia.www.haystack.external.ProtobufToJsonTransformer" additivity="false" level="INFO">
         <appender-ref ref="STDOUT" /><!-- Display start up message without flooding logs with other info messages -->
     </logger>
+    <logger name="com.netflix.servo.publish.graphite.GraphiteMetricObserver" additivity="false" level="INFO">
+        <appender-ref ref="STDOUT" /><!-- Display start up message without flooding logs with other info messages -->
+    </logger>
     <root level="WARN">
         <appender-ref ref="STDOUT" />
     </root>

--- a/src/test/java/com/expedia/www/haystack/external/SpanJsonSerializerTest.java
+++ b/src/test/java/com/expedia/www/haystack/external/SpanJsonSerializerTest.java
@@ -41,6 +41,9 @@ public class SpanJsonSerializerTest {
     @After
     public void tearDown() {
         SpanJsonSerializer.logger = realLogger;
+        SpanJsonSerializer.errorCount.increment(-((long) SpanJsonSerializer.errorCount.getValue()));
+        SpanJsonSerializer.requestCount.increment(-((long) SpanJsonSerializer.requestCount.getValue()));
+        SpanJsonSerializer.bytesIn.increment(-((long) SpanJsonSerializer.bytesIn.getValue()));
         verifyNoMoreInteractions(mockPrinter, mockLogger);
     }
 
@@ -50,6 +53,7 @@ public class SpanJsonSerializerTest {
 
         final String string = new String(byteArray);
         assertEquals(TestConstantsAndCommonCode.JSON_SPAN_STRING, string);
+        verifyCounters(0L, 1, byteArray.length);
     }
 
     @Test
@@ -64,6 +68,7 @@ public class SpanJsonSerializerTest {
         assertNull(shouldBeNull);
         verify(mockPrinter).print(span);
         verify(mockLogger).error(SpanJsonSerializer.ERROR_MSG, span, exception);
+        verifyCounters(1, 1, 0);
     }
 
     @Test
@@ -71,6 +76,7 @@ public class SpanJsonSerializerTest {
         final Printer printer = injectMockPrinter();
         spanJsonSerializer.configure(null, true);
         SpanJsonSerializer.printer = printer;
+        verifyCounters(0, 0, 0);
     }
 
     @Test
@@ -78,6 +84,7 @@ public class SpanJsonSerializerTest {
         final Printer printer = injectMockPrinter();
         spanJsonSerializer.close();
         SpanJsonSerializer.printer = printer;
+        verifyCounters(0, 0, 0);
     }
 
     private Printer injectMockPrinter() {
@@ -86,4 +93,9 @@ public class SpanJsonSerializerTest {
         return printer;
     }
 
+    private void verifyCounters(long errorCount, long requestCount, long bytesIn) {
+        assertEquals(errorCount, SpanJsonSerializer.errorCount.getValue());
+        assertEquals(requestCount, SpanJsonSerializer.requestCount.getValue());
+        assertEquals(bytesIn, SpanJsonSerializer.bytesIn.getValue());
+    }
 }


### PR DESCRIPTION
Graphite plain text messages. I have verified that the messages are
being sent, but the configurations on the InfluxDb (in the
haystack-deployment package) aren't yet what they need to be to allow
the plain text messages to be written to InfluxDb.